### PR TITLE
add dockerfile for local run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+
+FROM golang:1.21-alpine3.19
+
+ADD . /line-login-go
+WORKDIR /line-login-go
+
+RUN export GOFLAGS=-mod=vendor
+RUN cd /line-login-go && go build -o line-login-go
+
+ENTRYPOINT ["/line-login-go/line-login-go"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ Before deploy this to your Heroku, you will need complete as follows:
 - Crete a LINE Message API channel. Remember it's channel secret and token.
 - Link the chatbot to the LINE login channel
 
+Run In Docker
+=============
+
+```
+docker build -t line-login-go:latest .
+
+docker run \
+-e LINECORP_PLATFORM_CHATBOT_CHANNELSECRET=your_secret \
+-e LINECORP_PLATFORM_CHATBOT_CHANNELTOKEN=your_token \
+-e LINECORP_PLATFORM_SERVERURL=http://localhost:8080 \
+-e LINECORP_PLATFORM_CHANNEL_CHANNELID=your_channel_id \
+-e LINECORP_PLATFORM_CHANNEL_CHANNELSECRET=your_channel_secret \
+-e PORT=8080 \
+-p 8080:8080 \
+line-login-go
+```
+
 License
 =============
 


### PR DESCRIPTION
Hi,
Since Heroku has [removed its free plan](https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq), I add the dockerfile for developers to build and run in local.